### PR TITLE
Hire assassin bug

### DIFF
--- a/Roma/Scripts/DB_Events.json
+++ b/Roma/Scripts/DB_Events.json
@@ -533,24 +533,24 @@
 					"What": "Astutia",
 					"Value": -1
 				}
-			},
-			"RequiresCreator": 
+			}
+		},
+		"RequiresCreator": 
+		{
+			"Descriptions": 
 			{
-				"Descriptions": 
-				{
-					"When": "Creating",
-					"What": "Trait.Has Assassin.Level",
-					"Comparison": "=",
-					"Value": 0
-				},
+				"When": "Creating",
+				"What": "Trait.Has Assassin.Level",
+				"Comparison": "=",
+				"Value": 0
+			},
 
-				"Descriptions2": 
-				{
-					"When": "Creating",
-					"What": "Trait.Conspirator.Level",
-					"Comparison": "=",
-					"Value": 3
-				}
+			"Descriptions2": 
+			{
+				"When": "Creating",
+				"What": "Trait.Conspirator.Level",
+				"Comparison": "=",
+				"Value": 3
 			}
 		}
 	},

--- a/Roma/Scripts/DB_Events.json
+++ b/Roma/Scripts/DB_Events.json
@@ -539,9 +539,17 @@
 				"Descriptions": 
 				{
 					"When": "Creating",
-					"What": "Has Assassin",
+					"What": "Trait.Has Assassin.Level",
 					"Comparison": "=",
 					"Value": 0
+				},
+
+				"Descriptions2": 
+				{
+					"When": "Creating",
+					"What": "Trait.Conspirator.Level",
+					"Comparison": "=",
+					"Value": 3
 				}
 			}
 		}
@@ -578,7 +586,7 @@
 			"Descriptions": 
 			{
 				"When": "Creating",
-				"What": "Shadowing",
+				"What": "Trait.Shadowing.Level",
 				"Comparison": "=",
 				"Value": 0
 			}
@@ -656,7 +664,7 @@
 			"Descriptions": 
 			{
 				"When": "Creating",
-				"What": "Shadowing",
+				"What": "Trait.Shadowing.Level",
 				"Comparison": ">",
 				"Value": 0
 			}
@@ -734,7 +742,7 @@
 			"Descriptions": 
 			{
 				"When": "Creating",
-				"What": "Shadowing",
+				"What": "Trait.Shadowing.Level",
 				"Comparison": ">",
 				"Value": 0
 			}
@@ -924,6 +932,14 @@
 					"Type": "Change",
 					"What": "Dignitas",
 					"Value": -2
+				},
+				"Description3": 
+				{
+					"When": "Success",
+					"Who": "Creator",
+					"Type": "Set",
+					"What": "Trait.Conspirator.Level",
+					"Value": 3
 				}
 			},
 			"Falure": 
@@ -962,7 +978,7 @@
 			"Descriptions": 
 			{
 				"When": "Creating",
-				"What": "Shadowing",
+				"What": "Trait.Shadowing.Level",
 				"Comparison": ">",
 				"Value": 2
 			}


### PR DESCRIPTION
Requires Creator was included in Effects rather than being it's own category.